### PR TITLE
Specify beta in installation instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   directories:
   - node_modules
 install:
-  - npm install -g truffle
+  - npm install -g truffle@beta
   - npm install -g ganache-cli
   - npm install
 script:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Boilerplate for your next Smart Contract, made simple.
 1. Install Truffle and Ganache CLI globally.
 
 ```javascript
-npm install -g truffle
+npm install -g truffle@beta
 npm install -g ganache-cli
 ```
 


### PR DESCRIPTION
Since Truffle v5 hasn't yet been released as NPM `latest`